### PR TITLE
Fix Available CPU Check issue #32 /#47

### DIFF
--- a/plugins/modules/powervm_lpar_instance.py
+++ b/plugins/modules/powervm_lpar_instance.py
@@ -368,24 +368,29 @@ def init_logger():
         level=logging.DEBUG)
 
 
-def validate_proc_mem(system_dom, proc, mem, proc_units=None):
+def validate_proc_mem(system_dom, proc, mem, proc_unit=None):
 
     curr_avail_proc_units = system_dom.xpath('//CurrentAvailableSystemProcessorUnits')[0].text
-    int_avail_proc = int(float(curr_avail_proc_units))
+    curr_avail_procs = float(curr_avail_proc_units)
+    int_avail_proc = int(curr_avail_procs)
 
-    if proc_units:
+    if proc_unit:
         min_proc_unit_per_virtproc = system_dom.xpath('//MinimumProcessorUnitsPerVirtualProcessor')[0].text
         float_min_proc_unit_per_virtproc = float(min_proc_unit_per_virtproc)
-        if round(float(proc_units) % float_min_proc_unit_per_virtproc, 2) != float_min_proc_unit_per_virtproc:
-            raise HmcError("Input processor units: {0} must be a multiple of {1}".format(proc_units, min_proc_unit_per_virtproc))
+        if round(float(proc_unit) % float_min_proc_unit_per_virtproc, 2) != float_min_proc_unit_per_virtproc:
+            raise HmcError("Input processor units: {0} must be a multiple of {1}".format(proc_unit, min_proc_unit_per_virtproc))
+
+        if proc_unit > curr_avail_procs:
+            raise HmcError("{0} Available system proc units is not enough for {1} shared CPUs. Provide value on or below {0}".format(str(curr_avail_procs),str(proc_unit)))
+
+    else:
+        if proc > curr_avail_procs:
+            raise HmcError("{2} Available system proc units is not enough for {1} dedicated CPUs. Provide value on or below {0} CPUs".format(str(int_avail_proc),str(proc),str(curr_avail_procs)))
 
     curr_avail_mem = system_dom.xpath('//CurrentAvailableSystemMemory')[0].text
     int_avail_mem = int(curr_avail_mem)
     curr_avail_lmb = system_dom.xpath('//CurrentLogicalMemoryBlockSize')[0].text
     lmb = int(curr_avail_lmb)
-
-    if proc > int_avail_proc:
-        raise HmcError("Available system proc units is not enough. Provide value on or below {0}".format(str(int_avail_proc)))
 
     if mem % lmb > 0:
         raise HmcError("Requested mem value not in mutiple of block size:{0}".format(curr_avail_lmb))
@@ -747,7 +752,7 @@ def create_partition(module, params):
 
         return True, None, None
 
-    validate_proc_mem(server_dom, int(proc), int(mem))
+    validate_proc_mem(server_dom, int(proc), int(mem), proc_unit)
 
     if params['npiv_config']:
         fcports_config = fetch_fc_config(rest_conn, system_uuid, params['npiv_config'])

--- a/plugins/modules/powervm_lpar_instance.py
+++ b/plugins/modules/powervm_lpar_instance.py
@@ -376,16 +376,17 @@ def validate_proc_mem(system_dom, proc, mem, proc_unit=None):
 
     if proc_unit:
         min_proc_unit_per_virtproc = system_dom.xpath('//MinimumProcessorUnitsPerVirtualProcessor')[0].text
-        float_min_proc_unit_per_virtproc = float(min_proc_unit_per_virtproc)
-        if round(float(proc_unit) % float_min_proc_unit_per_virtproc, 2) != float_min_proc_unit_per_virtproc:
+        if Decimal(str(proc_unit)) % Decimal(min_proc_unit_per_virtproc) != Decimal('0.0'):
             raise HmcError("Input processor units: {0} must be a multiple of {1}".format(proc_unit, min_proc_unit_per_virtproc))
 
         if proc_unit > curr_avail_procs:
-            raise HmcError("{0} Available system proc units is not enough for {1} shared CPUs. Provide value on or below {0}".format(str(curr_avail_procs),str(proc_unit)))
+            raise HmcError("{0} Available system proc units is not enough for {1} shared CPUs. Provide value on or below {0}"
+                           .format(str(curr_avail_procs), str(proc_unit)))
 
-    else:
-        if proc > curr_avail_procs:
-            raise HmcError("{2} Available system proc units is not enough for {1} dedicated CPUs. Provide value on or below {0} CPUs".format(str(int_avail_proc),str(proc),str(curr_avail_procs)))
+else:
+    if proc > curr_avail_procs:
+        raise HmcError("{2} Available system proc units is not enough for {1} dedicated CPUs. Provide value on or below {0} CPUs"
+                       .format(str(int_avail_proc), str(proc), str(curr_avail_procs)))
 
     curr_avail_mem = system_dom.xpath('//CurrentAvailableSystemMemory')[0].text
     int_avail_mem = int(curr_avail_mem)


### PR DESCRIPTION
**Fix Available CPU Check issue #32  / #47** 
Shared CPU LPAR creation incorrectly  errors when not enough available CPUs to satisfy Logical Processors requested.

Fix for
**1. The "validate_proc_mem" function defines a new variable "proc_units" that is never set**

Added "proc_unit" variable when the function is called.
I have also changed "proc_units" to "proc_unit" in the validate_proc_mem function for consistency with the rest of the module.

**2. The "validate_proc_mem" function always performs check for sufficient dedicated CPUs**

Moved the Check for sufficient available Dedicated CPUs into an "else" following the check for "proc_unit" being defined.
Added an equivalent check for sufficient available shared CPUs at end of the "proc_unit" check.
I have also added more detail to the messages to explain the failure. It now shows the current available value as well as the qty requested and if it is for Dedicated CPU or Shared CPU.