### PR TITLE
Adding retrieve WWPN of NPIV as facts

### DIFF
--- a/plugins/module_utils/hmc_rest_client.py
+++ b/plugins/module_utils/hmc_rest_client.py
@@ -1024,6 +1024,13 @@ class HmcRestClient:
 
     def vios_fetch_fcports_info(self, viosuuid):
         vios_dom = self.getVirtualIOServer(viosuuid)
+        phys_fc_adapters = vios_dom.xpath("//VirtualFibreChannelMapping")
+        fc_adapters = {}
+        for adapter in phys_fc_adapters:
+            fc_port = adapter.find("Port")
+            if fc_port: 
+                location_code =  fc_port.find('LocationCode').text
+                fc_adapters[location_code] = adapter.find("ClientAdapter").find('WWPNs').text
         phys_fc_ports = vios_dom.xpath("//PhysicalFibreChannelPort")
         fc_ports = []
         available_ports = None
@@ -1036,6 +1043,9 @@ class HmcRestClient:
             fcport = {}
             fcport['LocationCode'] = each.xpath("LocationCode")[0].text
             fcport['PortName'] = each.xpath("PortName")[0].text
+            location_code = fcport['LocationCode'] 
+            if location_code in fc_adapters.keys():
+                fcport['wwpn_pair'] = fc_adapters[location_code]
             fc_ports.append(fcport)
         return fc_ports
 


### PR DESCRIPTION
Solving issue #40, about retrieve of details for WWPN of NPIV as facts in module **powervm_lpar_instance**, for parameter **state** in values **_present_** and **_facts_**.

Ex. Fragment of output:
{
    "LocationCode": "U78D3.001.WZS0A2A-P1-C8-T2",
    "PortName": "fcs1",
    "viosname": "VIOCHP906",
    "wwpn_pair": "c050760b5fe50160 c050760b5fe50161"
},
{
    "LocationCode": "U78D3.001.WZS0A2A-P1-C3-T2",
    "PortName": "fcs1",
    "viosname": "VIOCHP905",
    "wwpn_pair": "c050760b5fe50162 c050760b5fe50163"
},
{
    "LocationCode": "U78D3.001.WZS0A2A-P1-C8-T1",
    "PortName": "fcs0",
    "viosname": "VIOCHP906",
    "wwpn_pair": "c050760b5fe50164 c050760b5fe50165"
},
{
    "LocationCode": "U78D3.001.WZS0A2A-P1-C3-T1",
    "PortName": "fcs0",
    "viosname": "VIOCHP905",
    "wwpn_pair": "c050760b5fe50166 c050760b5fe50167"
}
