### PR TITLE
Add support to install linux OS using vm_mac paramter

### DIFF
--- a/plugins/module_utils/hmc_command_stack.py
+++ b/plugins/module_utils/hmc_command_stack.py
@@ -46,6 +46,8 @@ class HmcCommandStack():
                'LSHMCLDAP': 'lshmcldap',
                'CHHMCLDAP': 'chhmcldap',
                'LSUPDHMC': 'lsupdhmc',
+               'MKVTERM': 'mkvterm',
+               'RMVTERM': 'rmvterm'
                }
 
     HMC_CMD_OPT = {'LSHMC': {'-N': ' -n ',
@@ -319,7 +321,13 @@ class HmcCommandStack():
                                     '-L': ' -l ',
                                     '-V': ' -V ',
                                     '-Y': ' -Y ',
-                                    '-K': ' -K '},
+                                    '-K': ' -K ',
+                                    '-x': ' -x ',
+                                    '-v': ' -v ',
+                                    '-i': ' -i ',
+                                    '-d': ' -d ',
+                                    '-s': ' -s ',
+                                    '-m': ' -m '},
                    'LSREFCODE': {'-R': {'LPAR': ' -r lpar'},
                                  '-M': ' -m ',
                                  '-F': ' -F ',
@@ -424,6 +432,10 @@ class HmcCommandStack():
                                  'GROUPATTRIBUTE': ' --groupattribute',
                                  'MEMBERATTRIBUTE': ' --memberattribute'
                                  },
+                   'MKVTERM': {'-m': ' -m ',
+                               '-p': ' -p '},
+                   'RMVTERM': {'-m': ' -m ',
+                               '-p': ' -p '},
                    }
 
     def filterBuilder(self, cmdKey, configOptionsDict):

--- a/plugins/module_utils/hmc_resource.py
+++ b/plugins/module_utils/hmc_resource.py
@@ -8,11 +8,11 @@ __metaclass__ = type
 import time
 import re
 import subprocess
+import multiprocessing
 from ansible_collections.ibm.power_hmc.plugins.module_utils.hmc_command_stack import HmcCommandStack
 from ansible_collections.ibm.power_hmc.plugins.module_utils.hmc_cli_client import HmcCliConnection
 from ansible_collections.ibm.power_hmc.plugins.module_utils.hmc_exceptions import HmcError
 from ansible_collections.ibm.power_hmc.plugins.module_utils.hmc_exceptions import ParameterError
-
 import logging
 logger = logging.getLogger(__name__)
 
@@ -482,20 +482,52 @@ class Hmc():
         result = self.hmcconn.execute(lpar_netboot)
         return self._parseIODetailsFromNetboot(result)
 
-    def installOSFromNIM(self, loc_code, nimIP, gateway, lparIP, vlanID, vlanPrio, submask, viosName, profName, systemName):
-        lpar_netboot = self.CMD['LPAR_NETBOOT'] +\
-            self.OPT['LPAR_NETBOOT']['-F'] +\
+    def installOSFromNIM(self, loc_code, nimIP, gateway, lparIP, vlanID, vlanPrio, submask, viosName, profName, systemName, lparMac=None):
+        if loc_code:
+            os_command = self.OPT['LPAR_NETBOOT']['-L'] + loc_code +\
+                self.OPT['LPAR_NETBOOT']['-V'] + vlanID +\
+                self.OPT['LPAR_NETBOOT']['-Y'] + vlanPrio
+        elif lparMac:
+            os_command = self.OPT['LPAR_NETBOOT']['-x'] +\
+                self.OPT['LPAR_NETBOOT']['-v'] +\
+                self.OPT['LPAR_NETBOOT']['-i'] +\
+                self.OPT['LPAR_NETBOOT']['-s'] + "auto" +\
+                self.OPT['LPAR_NETBOOT']['-d'] + "auto" +\
+                self.OPT['LPAR_NETBOOT']['-m'] + lparMac
+        else:
+            pass
+
+        lpar_netboot = self.CMD['LPAR_NETBOOT'] + self.OPT['LPAR_NETBOOT']['-F'] +\
             self.OPT['LPAR_NETBOOT']['-D'] +\
             self.OPT['LPAR_NETBOOT']['-T'] + "ent" +\
-            self.OPT['LPAR_NETBOOT']['-L'] + loc_code +\
             self.OPT['LPAR_NETBOOT']['-S'] + nimIP +\
             self.OPT['LPAR_NETBOOT']['-G'] + gateway +\
             self.OPT['LPAR_NETBOOT']['-C'] + lparIP +\
-            self.OPT['LPAR_NETBOOT']['-V'] + vlanID +\
-            self.OPT['LPAR_NETBOOT']['-Y'] + vlanPrio +\
             self.OPT['LPAR_NETBOOT']['-K'] + submask +\
+            os_command +\
             " " + viosName + " " + profName + " " + systemName
         self.hmcconn.execute(lpar_netboot)
+
+    def getconsolelog(self, module, lpar_hmc, userid, hmc_password, systemName, lparName):
+        conn = HmcCliConnection(module, lpar_hmc, userid, hmc_password)
+        cmd = 'rmvterm -m ' + systemName + ' -p ' + lparName
+        conn.execute(cmd)
+        cmd = 'mkvterm -m ' + systemName + ' -p ' + lparName
+        stdout = conn.execute(cmd)
+        try:
+            for line in stdout:
+                logger.debug(line.strip())
+                logger.debug("\n")
+        except UnicodeDecodeError:
+            pass
+
+    def checkconsolelog(self, module, lpar_ip, lpar_hmc, userid, hmc_password, systemName, lparName):
+        logger.info("Installation will take approximatly 10-12 mins to complete.")
+        process = multiprocessing.Process(target=self.getconsolelog, args=(module, lpar_hmc, userid, hmc_password, systemName, lparName))
+        process.start()
+        time.sleep(360)
+        process.terminate()
+        process.join()
 
     def getPartitionRefcode(self, system_name, name):
         filter_config = dict(LPAR_NAMES=name)


### PR DESCRIPTION
Installation of Linux OS required changes in lpar_netboot command with addition to input paramter vm_mac from user.
When user inputs the vm_mac paramter, linux os installtion starts with the the help of lpar_netboot command with the additional options and vm_mac.