### PR TITLE
Adding roles for Supporting Linux OS installation

### DIFF
--- a/playbooks/roles/dhcp_remove/.travis.yml
+++ b/playbooks/roles/dhcp_remove/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/playbooks/roles/dhcp_remove/README.md
+++ b/playbooks/roles/dhcp_remove/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/playbooks/roles/dhcp_remove/defaults/main.yml
+++ b/playbooks/roles/dhcp_remove/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for dhcp_remove

--- a/playbooks/roles/dhcp_remove/handlers/main.yml
+++ b/playbooks/roles/dhcp_remove/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for dhcp_remove

--- a/playbooks/roles/dhcp_remove/meta/main.yml
+++ b/playbooks/roles/dhcp_remove/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/playbooks/roles/dhcp_remove/tasks/main.yml
+++ b/playbooks/roles/dhcp_remove/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Copy dhcpd.conf to temporary directory
+  shell: cp /etc/dhcp/dhcpd.conf /tmp/dhcpd.conf
+- name: Delete dhcp entry of lpar
+  blockinfile:
+    dest: /etc/dhcp/dhcpd.conf
+    marker: "#{mark} Ansible module dhcp entry"
+    block: "{{ lookup('template', 'dhcpd_conf.j2') }}"
+    state: absent
+- name: Restart dhcpd service
+  shell: systemctl restart  dhcpd.service

--- a/playbooks/roles/dhcp_remove/templates/dhcpd_conf.j2
+++ b/playbooks/roles/dhcp_remove/templates/dhcpd_conf.j2
@@ -1,0 +1,15 @@
+subnet {{ host_subnet }} netmask {{ host_netmask }} {
+    allow bootp;
+    option routers {{ host_gw }};
+    option domain-name-servers {{ dns_ip }};
+    option domain-name "abc.def.ght.com";
+    group {
+        next-server {{ hostvars['pxe'].ansible_host }};
+        filename "{{ core_file_path }}";
+              host {{ hostname }} {
+                        hardware ethernet {{ hardware_ethernet }};
+                        fixed-address {{ host_ip }};
+            option tftp-server-name "{{ hostvars['pxe'].ansible_host }}";
+        }
+    }
+}

--- a/playbooks/roles/dhcp_remove/tests/inventory
+++ b/playbooks/roles/dhcp_remove/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/playbooks/roles/dhcp_remove/tests/test.yml
+++ b/playbooks/roles/dhcp_remove/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - dhcp_remove

--- a/playbooks/roles/dhcp_remove/vars/main.yml
+++ b/playbooks/roles/dhcp_remove/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for dhcp_remove

--- a/playbooks/roles/dhcp_setup/README.md
+++ b/playbooks/roles/dhcp_setup/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/playbooks/roles/dhcp_setup/defaults/main.yml
+++ b/playbooks/roles/dhcp_setup/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for dhcp_setup

--- a/playbooks/roles/dhcp_setup/handlers/main.yml
+++ b/playbooks/roles/dhcp_setup/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for dhcp_setup

--- a/playbooks/roles/dhcp_setup/meta/main.yml
+++ b/playbooks/roles/dhcp_setup/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/playbooks/roles/dhcp_setup/tasks/main.yml
+++ b/playbooks/roles/dhcp_setup/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Copy dhcpd.conf to temporary directory
+  shell: cp /etc/dhcp/dhcpd.conf /tmp/dhcpd.conf
+- name: Edit dhcpd.conf with latest entry
+  blockinfile:
+    marker: "#{mark} Ansible module dhcp entry"
+    dest: /etc/dhcp/dhcpd.conf
+    block: "{{ lookup('template', 'dhcpd_conf.j2') }}"
+- name: Restart dhcpd service
+  shell: systemctl restart  dhcpd.service
+
+

--- a/playbooks/roles/dhcp_setup/templates/dhcpd_conf.j2
+++ b/playbooks/roles/dhcp_setup/templates/dhcpd_conf.j2
@@ -1,0 +1,15 @@
+subnet {{ host_subnet }} netmask {{ host_netmask }} {
+    allow bootp;
+    option routers {{ host_gw }};
+    option domain-name-servers {{ dns_ip }};
+    option domain-name "aus.stglabs.ibm.com";
+    group {
+        next-server {{ hostvars['pxe'].ansible_host }};
+        filename "{{ core_file_path }}";
+              host {{ hostname }} {
+                        hardware ethernet {{ hardware_ethernet }};
+                        fixed-address {{ host_ip }};
+            option tftp-server-name "{{ hostvars['pxe'].ansible_host }}";
+        }
+    }
+}

--- a/playbooks/roles/dhcp_setup/tests/inventory
+++ b/playbooks/roles/dhcp_setup/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/playbooks/roles/dhcp_setup/tests/test.yml
+++ b/playbooks/roles/dhcp_setup/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - dhcp_setup

--- a/playbooks/roles/dhcp_setup/vars/main.yml
+++ b/playbooks/roles/dhcp_setup/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# vars file for dhcp_setup
+repo_port: 81

--- a/playbooks/roles/ks_generation/README.md
+++ b/playbooks/roles/ks_generation/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/playbooks/roles/ks_generation/defaults/main.yml
+++ b/playbooks/roles/ks_generation/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for ks_generation

--- a/playbooks/roles/ks_generation/handlers/main.yml
+++ b/playbooks/roles/ks_generation/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ks_generation

--- a/playbooks/roles/ks_generation/meta/main.yml
+++ b/playbooks/roles/ks_generation/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/playbooks/roles/ks_generation/tasks/main.yml
+++ b/playbooks/roles/ks_generation/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Create KS file name
+  set_fact:
+    ks_file: "{{ distro | regex_replace('\\.', '') }}_{{ hardware_ethernet }}.ks"
+- name: Path to the build in repo server
+  set_fact:
+    repo_dir: "/crtl/repo/rhel/{{ distro }}"
+- name: Create a file
+  template:
+    src: templates/ks.j2
+    dest: "/var/www/html/linux_ks/{{ ks_file }}"

--- a/playbooks/roles/ks_generation/templates/ks.j2
+++ b/playbooks/roles/ks_generation/templates/ks.j2
@@ -1,0 +1,51 @@
+# Use text mode install
+text
+# Reboot after installation
+reboot
+
+%post
+sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config;service sshd restart;multipath -t >/etc/multipath.conf;service multipathd start
+%end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+
+%end
+
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+
+# Network information
+network  --hostname="{{ hostname }}"
+
+# Use network installation
+url --url="http://{{ hostvars['repo'].ansible_host }}:{{ repo_port }}{{ repo_dir }}/BaseOS"
+
+%packages
+@core
+device-mapper-multipath
+kexec-tools
+
+%end
+
+# System services
+services --enabled="NetworkManager,sshd"
+# Do not configure the X Window System
+skipx
+
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel --drives=sda
+# System bootloader configuration
+bootloader --append="crashkernel=2G-4G:384M,4G-16G:512M,16G-64G:1G,64G-128G:2G,128G-:4G" --location=mbr --boot-drive=sda
+autopart --fstype=ext4
+# Generated using Blivet version 3.6.0
+ignoredisk --only-use=sda
+
+# System timezone
+timezone Asia/Kolkata --utc
+
+# Root password
+rootpw --plaintext password

--- a/playbooks/roles/ks_generation/tests/inventory
+++ b/playbooks/roles/ks_generation/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/playbooks/roles/ks_generation/tests/test.yml
+++ b/playbooks/roles/ks_generation/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ks_generation

--- a/playbooks/roles/ks_generation/vars/main.yml
+++ b/playbooks/roles/ks_generation/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# vars file for ks_generation
+repo_port: 81

--- a/playbooks/roles/post_installation_log/README.md
+++ b/playbooks/roles/post_installation_log/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/playbooks/roles/post_installation_log/defaults/main.yml
+++ b/playbooks/roles/post_installation_log/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for post_installation_log

--- a/playbooks/roles/post_installation_log/handlers/main.yml
+++ b/playbooks/roles/post_installation_log/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for post_installation_log

--- a/playbooks/roles/post_installation_log/meta/main.yml
+++ b/playbooks/roles/post_installation_log/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/playbooks/roles/post_installation_log/tasks/main.yml
+++ b/playbooks/roles/post_installation_log/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Check if ansible_pwer_hmc.log file exists
+  stat:
+    path: /tmp/ansible_power_hmc.log
+  register: log_file_info
+
+- name: Fail if ansible_power_hmc.log file is not found
+  fail:
+    msg: "Installation log file not found: /tmp/ansible_power_hmc.log"
+  when: log_file_info.stat.exists == false
+
+- name: Check log file for bug-related messages
+  become: true
+  shell: "grep -E 'Oops|Call Trace|Entering emergency mode' /tmp/ansible_power_hmc.log"
+  register: log_results
+  ignore_errors: true
+  when: log_file_info.stat.exists
+
+- name: Display bug-related messages if found
+  fail:
+    msg: "Installation failed"
+  when: log_results.stdout_lines|length > 0
+
+- name: Print success message
+  debug:
+    msg: "Installation success"
+  when: log_results.stdout_lines|length == 0
+                                                 

--- a/playbooks/roles/post_installation_log/tests/inventory
+++ b/playbooks/roles/post_installation_log/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/playbooks/roles/post_installation_log/tests/test.yml
+++ b/playbooks/roles/post_installation_log/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - post_installation_log

--- a/playbooks/roles/post_installation_log/vars/main.yml
+++ b/playbooks/roles/post_installation_log/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for post_installation_log

--- a/playbooks/roles/post_installation_lpar/README.md
+++ b/playbooks/roles/post_installation_lpar/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/playbooks/roles/post_installation_lpar/defaults/main.yml
+++ b/playbooks/roles/post_installation_lpar/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for post_installation_lpar

--- a/playbooks/roles/post_installation_lpar/handlers/main.yml
+++ b/playbooks/roles/post_installation_lpar/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for post_installation_lpar

--- a/playbooks/roles/post_installation_lpar/meta/main.yml
+++ b/playbooks/roles/post_installation_lpar/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/playbooks/roles/post_installation_lpar/tasks/main.yml
+++ b/playbooks/roles/post_installation_lpar/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Check login status
+  shell: echo "Login successful"
+  register: login_status
+  ignore_errors: yes
+
+- name: Fail if unable to login
+  fail:
+    msg: "Failed to login to LPAR"
+  when: login_status.rc != 0
+
+- name: Run command on LPAR
+  shell: cat /etc/os-release| grep PRETTY|  awk -F= '{print $2}' | awk -F\" '{print $2}'
+  register: command_output
+
+- name: Display command output
+  debug:
+    var: command_output
+

--- a/playbooks/roles/post_installation_lpar/tests/inventory
+++ b/playbooks/roles/post_installation_lpar/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/playbooks/roles/post_installation_lpar/tests/test.yml
+++ b/playbooks/roles/post_installation_lpar/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - post_installation_lpar

--- a/playbooks/roles/post_installation_lpar/vars/main.yml
+++ b/playbooks/roles/post_installation_lpar/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for post_installation_lpar

--- a/playbooks/roles/tftp_setup/README.md
+++ b/playbooks/roles/tftp_setup/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/playbooks/roles/tftp_setup/defaults/main.yml
+++ b/playbooks/roles/tftp_setup/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for tftp_setup

--- a/playbooks/roles/tftp_setup/handlers/main.yml
+++ b/playbooks/roles/tftp_setup/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for tftp_setup

--- a/playbooks/roles/tftp_setup/meta/main.yml
+++ b/playbooks/roles/tftp_setup/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/playbooks/roles/tftp_setup/tasks/main.yml
+++ b/playbooks/roles/tftp_setup/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Remove ':' in hardware ethernet address
+  set_fact:
+    mac_address: "{{ hardware_ethernet | regex_replace(':', '') }}"
+- name: Path to the ks file
+  set_fact:
+    ks_path: /linux_ks/{{ hostvars['repo']['ks_file'] }}
+- name: Append base directory path with a new directory named by mac address
+  set_fact:
+    dest_dir: "{{ base_dir }}{{ mac_address }}"
+- name: Append base directory path with a new directory named by mac address
+  shell: rm -rf {{ dest_dir }}
+- name: Calculate cutdir value
+  shell: echo "{{ hostvars['repo']['repo_dir'] }}" | tr '/' '\n' | grep -v "^$" | wc -l
+  register: cut_dir
+- name: Download files from /boot dir
+  shell: wget -r --reject="index.html*" --no-parent -nH --cut-dir={{ cut_dir.stdout | int + 1 }}   http://{{ hostvars['repo'].ansible_host }}:{{ repo_port }}/{{ hostvars['repo']['repo_dir'] }}/boot/ -P {{ dest_dir }}
+- name: Download files from /ppc dir
+  shell: wget -r --reject="index.html*" --no-parent -nH --cut-dir={{ cut_dir.stdout | int + 1 }}   http://{{ hostvars['repo'].ansible_host }}:{{ repo_port }}/{{ hostvars['repo']['repo_dir'] }}/ppc/ -P {{ dest_dir }}
+- name: Create netboot dir
+  shell: grub2-mknetdir --net-directory={{ base_dir }} --subdir={{ mac_address }}/boot/grub/
+- name: Create grub.cfg
+  template:
+    src: templates/grub_conf.j2
+    dest: "{{ dest_dir }}/boot/grub/grub.cfg"
+- name: Set core elf file path
+  set_fact:
+    core_file_path: "{{ mac_address }}/boot/grub/powerpc-ieee1275/core.elf"
+- name: Replace ':' in hardware ethernet address wit '-'
+  set_fact:
+    address: "{{ hardware_ethernet | regex_replace(':', '-') }}"
+- name: Copy the grub.cfg to boot/grub/powerpc-ieee1275/ directory
+  shell: cp "{{ dest_dir }}/boot/grub/grub.cfg" "{{ dest_dir }}/boot/grub/powerpc-ieee1275/grub.cfg-01-{{ address }}"

--- a/playbooks/roles/tftp_setup/templates/grub_conf.j2
+++ b/playbooks/roles/tftp_setup/templates/grub_conf.j2
@@ -1,0 +1,9 @@
+set timeout=1
+menuentry 'Install OS' {
+    insmod http
+    insmod tftp
+    set root=tftp,{{ hostvars['pxe'].ansible_host }}
+    echo 'Loading OS Install kernel ...'
+    linux {{ mac_address }}/ppc/ppc64/vmlinuz ifname=net0:{{ hardware_ethernet }} ip={{ host_ip }}::{{ host_gw }}:{{ host_netmask }}:{{ hostname }}:net0:none nameserver={{ dns_ip }} inst.repo=http://{{ hostvars['repo'].ansible_host }}:{{ repo_port }}{{ hostvars['repo']['repo_dir'] }} inst.ks=http://{{ hostvars['repo'].ansible_host }}:{{ repo_port }}/{{ ks_path}}
+    initrd {{ mac_address }}/ppc/ppc64/initrd.img
+}

--- a/playbooks/roles/tftp_setup/tests/inventory
+++ b/playbooks/roles/tftp_setup/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/playbooks/roles/tftp_setup/tests/test.yml
+++ b/playbooks/roles/tftp_setup/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - tftp_setup

--- a/playbooks/roles/tftp_setup/vars/main.yml
+++ b/playbooks/roles/tftp_setup/vars/main.yml
@@ -1,0 +1,4 @@
+---
+# vars file for tftp_setup
+repo_port: 81
+base_dir: /var/lib/tftpboot/


### PR DESCRIPTION
Roles have ben added to create,
1. Kickstart file - Drive the automated OS installation
2. DHCP setup - Add the lpar entry in DHCP config file inside DHCP server
3. TFTP setup - Add the tftp/grub related files for OS to be installed in accordence with lpar mac address
4. DHCP remove  - cleanup the DHCP config for the lpar created
5. Post instalation lpar - Login to lpar to verify the OS is installed successfully
6. Post installation log - Verify the ansible generated logs to grep for any failure in installation