### PR TITLE
Adding role for Supporting Linux OS installation

### DIFF
--- a/playbooks/redhat_linux_install.yaml
+++ b/playbooks/redhat_linux_install.yaml
@@ -1,0 +1,24 @@
+---
+- name: Install linux
+  hosts: vm
+  collections:
+    - ibm.power_hmc
+  gather_facts: false
+  roles:
+    - role: redhat_linux_install
+      vars:
+        distro: Rhel9.1le
+        repo_dir: /rc-2.0/
+        host_ip: 1.2.3.4
+        host_gw: 1.2.3.1
+        host_subnet: 1.2.3.0
+        host_netmask: 255.255.255.0
+        dns_ip: 1.0.0.1
+        hostname: abc.hmc.com
+        lpar_name: abc-02
+        managed_system: abc-24
+        network_name: test
+        mem: 6144
+        proc: 4
+        disk_size: 28590
+        host_password: "{{ hostvars[groups['vm'][0]].ansible_password }}"

--- a/plugins/modules/powervm_lpar_instance.py
+++ b/plugins/modules/powervm_lpar_instance.py
@@ -1697,7 +1697,7 @@ def install_aix_os(module, params):
         rmc_state, vm_property, ref_code = hmc.checkForOSToBootUpFully(system_name, vm_name, timeout)
         if rmc_state:
             changed = True
-        elif ref_code in ['', '00']:
+        elif ref_code in ['', '00', 'Linux ppc64le']:
             changed = True
             warn_msg = "AIX/Linux installation has been successfull but RMC didnt come up, please check the HMC firewall and security"
         elif vm_mac and "linux" in vm_property['os_version'].lower():

--- a/roles/redhat_linux_install/README.md
+++ b/roles/redhat_linux_install/README.md
@@ -1,0 +1,178 @@
+Role Name
+=========
+
+This Ansible role "Red Hat Linux Installation for IBM PowerVM" automates the process of installing Red Hat Enterprise Linux (RHEL) on IBM PowerVM logical partitions (LPARs) using a **network-based installation via TFTP boot**.
+
+
+## Overview
+
+This Ansible role automates the installation of Red Hat Enterprise Linux (RHEL) on IBM PowerVM logical partitions (LPARs) using a network-based TFTP boot method. It orchestrates the entire setup process including infrastructure configuration, VM provisioning, and OS deployment.
+
+The role is designed to handle both existing and non-existing LPAR scenarios:
+
+- If the LPAR already exists, the user can specify the `network_name` to attach the appropriate virtual network.
+- If the LPAR does not exist, the role will automatically create one. In this case, the user must provide values for `network_name`, `mem`, `proc` and `volume_size`. If these parameters are omitted, default values defined in the role's `vars` will be used.
+
+> ⚠️ **Note:** This role does not support idempotency. Re-running the playbook may result in duplicate or conflicting configurations. This role supports single LPAR installation in a playbook run.
+
+
+## Required Infrastructure
+
+To perform the installation, the following components must be configured:
+
+1. **HTTP (Repo) Server**
+   Hosts the RHEL distribution files and serves them via HTTP. This can be a dedicated server with multiple distro builds or a simple HTTP server with the required build.
+
+2. **PXE Server**
+   Runs both `tftpd` and `dhcpd` services. This role will configure these services if they are not already running.
+
+3. **LPAR (Logical Partition)**
+   The target system where RHEL will be installed. If LPAR is not available, it will be created by using the given details
+
+## Role Workflow
+
+1. **LPAR Existence Check and Creation**
+- Checks if the LPAR already exists on the HMC.
+- If not found, creates a new LPAR with the specified network configuration and volume size.
+
+2. **MAC Address Retrieval and Formatting**
+- Retrieves the MAC address of the LPAR. 
+- Converts the MAC address into colon and hyphen formats for use in DHCP and GRUB configurations.
+
+3. **DHCP and TFTP Service Setup**
+- Checks if DHCP and TFTP services are running on the PXE server.
+- Installs and configures these services if not already running.
+- Calculates DHCP range and generates configuration using templates.
+
+4. **Kickstart File Generation**
+- Creates a kickstart file on the repository server using a Jinja2 template.
+
+5. **Boot File Preparation and GRUB Configuration**
+- Downloads required boot files from the repository server to the PXE server.
+- Creates GRUB netboot directory and configuration files.
+- Copies GRUB configuration to appropriate boot paths.
+
+6. **DHCP Configuration Updates and Reversion**
+- Adds LPAR-specific DHCP entries to the PXE server configuration.
+- Restarts DHCP service to apply changes.
+- Reverts DHCP configuration after installation.
+
+7. **Network Boot Initiation**
+- Executes `lpar_netboot` from the HMC to initiate network boot on the LPAR.
+
+8. **Post-Installation Validation**
+- Waits for SSH availability on the LPAR.
+- Gathers system facts and prints OS distribution and version.
+
+Role Variables
+--------------
+
+1. distro:
+   * type: str
+   * required: true
+   * description: Redhat distribution version in format Redhat9.3
+
+2. repo_dir:
+   * type: str
+   * required: optional
+   * description: The path in which http server is hosting the redhat repository, can be in default path /var/www/html/ a directory "crtl". Specify in format "crtl", this is used in roles as http://abc.com/crtl/
+
+3. curr_hmc_auth:
+   * type: str
+   * required: true
+   * description: Username and Password to login to HMC system, For security purposes, it is highly recommended to store this sensitive information in an encrypted secret vault file.
+
+4. host_ip/host_gw/host_subnet/host_netmask: 
+   * type: str
+   * required: true
+   * description: lpar Network details in format 9.9.9.9
+
+5. dns_ip: 
+   * type: str
+   * required: true
+   * description: Nameserver IP details in format 9.1.1.1
+
+6. hostname: 
+   * type: str
+   * required: true
+   * description: hostname of the lpar in format aaa.abc.com
+
+7. lpar_name: 
+   * type: str
+   * required: true
+   * desription: name of lpar as in the HMC 
+
+8. network_name:
+   * type: str
+   * required: true
+   * description: Name of the Virtual Network to be attached to the lpar.
+
+9. managed_system: 
+    * type: str
+    * required: true
+    * description: system name in HMC in which lpar is available 
+
+10. disk_size:
+    * type: int
+    * required: true
+    * description: Physical volume size in MB. Required while creating LPAR
+
+11. mem:
+    * type: int
+    * required: true
+    * description: The value of dedicated memory value in megabytes to create a partition, Default value is '2048 MB'. Required while creating LPAR
+
+12. proc:
+    * type: int
+    * required: true
+    * description: The number of dedicated processors to create a partition. Default value is '2'. This will not work during shared processor setting. 
+    
+                
+Example Playbook
+----------------
+        ---
+        - name: Redhat Install linux
+          hosts: vm
+          collections:
+            - ibm.power_hmc
+          gather_facts: false
+          roles:
+            - role: redhat_linux_install
+              vars:
+                host_ip: 9.9.9.9
+                host_gw: 9.9.9.1
+                host_subnet: 9.9.9.0
+                host_netmask: 255.255.255.0
+                dns_ip: 9.1.1.1
+                hostname: aaa.abc.com
+                lpar_name: name_in_hmc
+                netowrk_name: test
+                mem: 6144
+                proc: 4
+                disk_size: 28590
+                managed_system: system_name_in_HMC
+
+Inventory file with detials of pxe server, repository server and HMC server is required while running the playbook
+---------
+For security purposes, it is highly recommended to store this sensitive information in an encrypted secret vault file.
+        
+	
+	[repo]
+	repo_server  ansible_host=1.4.2.5 ansible_become_pass='abcd' ansible_user=hmc ansible_password=abcd
+	[pxe]
+	pxe_server  ansible_host=1.4.2.9 ansible_become_pass='abcd' ansible_user=root ansible_password=abcd
+	[hmcs]
+	hmc_server ansible_host=1.4.2.2 ansible_become_pass='abcd'  ansible_user=root ansible_password=abcd
+	[vm]
+	host_vm ansible_host=aaa.abc.com ansible_user=root ansible_password=abcd host_ip=9.9.9.9
+
+-----------
+License
+-------
+
+GPL-3.0-only
+
+Author Information
+------------------
+
+Spoorthy S

--- a/roles/redhat_linux_install/README.rst
+++ b/roles/redhat_linux_install/README.rst
@@ -1,0 +1,178 @@
+Role Name
+=========
+
+This Ansible role "Red Hat Linux Installation for IBM PowerVM" automates the process of installing Red Hat Enterprise Linux (RHEL) on IBM PowerVM logical partitions (LPARs) using a **network-based installation via TFTP boot**.
+
+
+## Overview
+
+This Ansible role automates the installation of Red Hat Enterprise Linux (RHEL) on IBM PowerVM logical partitions (LPARs) using a network-based TFTP boot method. It orchestrates the entire setup process including infrastructure configuration, VM provisioning, and OS deployment.
+
+The role is designed to handle both existing and non-existing LPAR scenarios:
+
+- If the LPAR already exists, the user can specify the `network_name` to attach the appropriate virtual network.
+- If the LPAR does not exist, the role will automatically create one. In this case, the user must provide values for `network_name`, `mem`, `proc` and `volume_size`. If these parameters are omitted, default values defined in the role's `vars` will be used.
+
+> ⚠️ **Note:** This role does not support idempotency. Re-running the playbook may result in duplicate or conflicting configurations.
+
+
+## Required Infrastructure
+
+To perform the installation, the following components must be configured:
+
+1. **HTTP (Repo) Server**
+   Hosts the RHEL distribution files and serves them via HTTP. This can be a dedicated server with multiple distro builds or a simple HTTP server with the required build.
+
+2. **PXE Server**
+   Runs both `tftpd` and `dhcpd` services. This role will configure these services if they are not already running.
+
+3. **LPAR (Logical Partition)**
+   The target system where RHEL will be installed. If LPAR is not available, it will be created by using the given details
+
+## Role Workflow
+
+1. **LPAR Existence Check and Creation**
+- Checks if the LPAR already exists on the HMC.
+- If not found, creates a new LPAR with the specified network configuration and volume size.
+
+2. **MAC Address Retrieval and Formatting**
+- Retrieves the MAC address of the LPAR. 
+- Converts the MAC address into colon and hyphen formats for use in DHCP and GRUB configurations.
+
+3. **DHCP and TFTP Service Setup**
+- Checks if DHCP and TFTP services are running on the PXE server.
+- Installs and configures these services if not already running.
+- Calculates DHCP range and generates configuration using templates.
+
+4. **Kickstart File Generation**
+- Creates a kickstart file on the repository server using a Jinja2 template.
+
+5. **Boot File Preparation and GRUB Configuration**
+- Downloads required boot files from the repository server to the PXE server.
+- Creates GRUB netboot directory and configuration files.
+- Copies GRUB configuration to appropriate boot paths.
+
+6. **DHCP Configuration Updates and Reversion**
+- Adds LPAR-specific DHCP entries to the PXE server configuration.
+- Restarts DHCP service to apply changes.
+- Reverts DHCP configuration after installation.
+
+7. **Network Boot Initiation**
+- Executes `lpar_netboot` from the HMC to initiate network boot on the LPAR.
+
+8. **Post-Installation Validation**
+- Waits for SSH availability on the LPAR.
+- Gathers system facts and prints OS distribution and version.
+
+Role Variables
+--------------
+
+1. distro:
+   * type: str
+   * required: true
+   * description: Redhat distribution version in format Redhat9.3
+
+2. repo_dir:
+   * type: str
+   * required: optional
+   * description: The path in which http server is hosting the redhat repository, can be in default path /var/www/html/ a directory "crtl". Specify in format "crtl", this is used in roles as http://abc.com/crtl/
+
+3. curr_hmc_auth:
+   * type: str
+   * required: true
+   * description: Username and Password to login to HMC system, For security purposes, it is highly recommended to store this sensitive information in an encrypted secret vault file.
+
+4. host_ip/host_gw/host_subnet/host_netmask: 
+   * type: str
+   * required: true
+   * description: lpar Network details in format 9.9.9.9
+
+5. dns_ip: 
+   * type: str
+   * required: true
+   * description: Nameserver IP details in format 9.1.1.1
+
+6. hostname: 
+   * type: str
+   * required: true
+   * description: hostname of the lpar in format aaa.abc.com
+
+7. lpar_name: 
+   * type: str
+   * required: true
+   * desription: name of lpar as in the HMC 
+
+8. network_name:
+   * type: str
+   * required: true
+   * description: Name of the Virtual Network to be attached to the lpar.
+
+9. managed_system: 
+    * type: str
+    * required: true
+    * description: system name in HMC in which lpar is available 
+
+10. disk_size:
+    * type: int
+    * required: true
+    * description: Physical volume size in MB. Required while creating LPAR
+
+11. mem:
+    * type: int
+    * required: true
+    * description: The value of dedicated memory value in megabytes to create a partition, Default value is '2048 MB'. Required while creating LPAR
+
+12. proc:
+    * type: int
+    * required: true
+    * description: The number of dedicated processors to create a partition. Default value is '2'. This will not work during shared processor setting. 
+    
+                
+Example Playbook
+----------------
+        ---
+        - name: Redhat Install linux
+          hosts: vm
+          collections:
+            - ibm.power_hmc
+          gather_facts: false
+          roles:
+            - role: redhat_linux_install
+              vars:
+                host_ip: 9.9.9.9
+                host_gw: 9.9.9.1
+                host_subnet: 9.9.9.0
+                host_netmask: 255.255.255.0
+                dns_ip: 9.1.1.1
+                hostname: aaa.abc.com
+                lpar_name: name_in_hmc
+                netowrk_name: test
+                mem: 6144
+                proc: 4
+                disk_size: 28590
+                managed_system: system_name_in_HMC
+
+Inventory file with detials of pxe server, repository server and HMC server is required while running the playbook
+---------
+For security purposes, it is highly recommended to store this sensitive information in an encrypted secret vault file.
+        
+	
+	[repo]
+	repo_server  ansible_host=1.4.2.5 ansible_become_pass='abcd' ansible_user=hmc ansible_password=abcd
+	[pxe]
+	pxe_server  ansible_host=1.4.2.9 ansible_become_pass='abcd' ansible_user=root ansible_password=abcd
+	[hmcs]
+	hmc_server ansible_host=1.4.2.2 ansible_become_pass='abcd'  ansible_user=root ansible_password=abcd
+	[vm]
+	host_vm ansible_host=aaa.abc.com ansible_user=root ansible_password=abcd host_ip=9.9.9.9
+
+-----------
+License
+-------
+
+GPL-3.0-only
+
+Author Information
+------------------
+
+Spoorthy S

--- a/roles/redhat_linux_install/meta/main.yml
+++ b/roles/redhat_linux_install/meta/main.yml
@@ -1,0 +1,12 @@
+galaxy_info:
+  author: Spoorthy S
+  description: Redhat Linux installation using pxe server
+  license: GPL-3.0-only
+  min_ansible_version: '>=2.14.0'
+  galaxy_tags:
+    - infrastructure
+    - ibm
+    - power
+    - hmc
+    - linux
+    - pxe

--- a/roles/redhat_linux_install/tasks/main.yml
+++ b/roles/redhat_linux_install/tasks/main.yml
@@ -1,0 +1,359 @@
+---
+- name: Create new lpar
+  run_once: true
+  connection: local
+  collections:
+      - ibm.power_hmc
+  powervm_lpar_instance:
+      hmc_host: "{{ hostvars['hmc_server'].ansible_host }}"
+      hmc_auth: '{{ curr_hmc_auth }}'
+      system_name: "{{ managed_system }}"
+      vm_name: "{{ lpar_name }}"
+      os_type: linux
+      proc: "{{ proc }}"
+      mem: "{{ mem }}"
+      virt_network_config:
+          - network_name: "{{ network_name }}"
+      volume_config:
+          - volume_size: "{{ disk_size }}"
+      state: present
+  delegate_to: "{{ groups['hmcs'][0] }}"
+
+- name: Retrieve the MAC address and fail with custom message if no network adapters
+  run_once: true
+  connection: local
+  collections:
+      - ibm.power_hmc
+  block:
+      - name: Checking if any adapter is pingable
+        hmc_command:
+            hmc_host: "{{ hostvars['hmc_server'].ansible_host }}"
+            hmc_auth: '{{ curr_hmc_auth }}'
+            cmd: >
+              lpar_netboot -A -M -n -D -t ent
+              -S {{ hostvars[groups['pxe'][0]].ansible_host }}
+              -G {{ host_gw }}
+              -K {{ host_netmask }}
+              -C {{ host_ip }}
+              {{ lpar_name }} default_profile {{ managed_system }}
+        register: mac_command_result
+        failed_when: false
+
+      - name: Fail if no network adapters found or no successful adapter
+        ansible.builtin.fail:
+            msg: "There are no network adapters pingable or no successful adapters found for LPAR {{ lpar_name }}."
+        when: >
+          mac_command_result.command_output is not defined or
+          ('No network adapters found' in (mac_command_result.command_output | default([]) | join('\n'))) or
+          ('Unable to obtain network adapter information' in (mac_command_result.msg | default(''))) or
+          (((mac_command_result.command_output | default([]) | join('\n')) |
+          regex_findall('ent[\s\t]+\S+[\s\t]+([0-9a-fA-F]{12})[\s\t]+\S+[\s\t]+successful')) | length == 0)
+
+      - name: Set MAC address fact
+        ansible.builtin.set_fact:
+            mac_address: >-
+              {{
+                (
+                  (mac_command_result.command_output | default([]) | join('\n'))
+                  | regex_findall('ent[\s\t]+\S+[\s\t]+([0-9a-fA-F]{12})[\s\t]+\S+[\s\t]+successful')
+                )[0] | lower
+              }}
+        when: >
+          mac_command_result.command_output is defined and
+          (((mac_command_result.command_output | default([]) | join('\n')) |
+          regex_findall('ent[\s\t]+\S+[\s\t]+([0-9a-fA-F]{12})[\s\t]+\S+[\s\t]+successful')) | length > 0)
+
+- name: Convert MAC address in colon format from fact variable
+  ansible.builtin.set_fact:
+      hardware_ethernet: "{{ mac_address | regex_replace('(..)(..)(..)(..)(..)(..)', '\\1:\\2:\\3:\\4:\\5:\\6') }}"
+
+- name: Convert MAC address from in hyphen format from fact variable
+  ansible.builtin.set_fact:
+      address: "{{ mac_address | regex_replace('(..)(..)(..)(..)(..)(..)', '\\1-\\2-\\3-\\4-\\5-\\6') }}"
+
+- name: Gather service facts
+  run_once: true
+  ansible.builtin.service_facts:
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Check if the pxe server has dhcp and tftp services running
+  run_once: true
+  ansible.builtin.set_fact:
+      dhcpd_running: "{{ 'dhcpd.service' in services and services['dhcpd.service'].state == 'running' }}"
+      tftp_running: >-
+        {{ ('tftp.service' in services and services['tftp.service'].state == 'running') or
+          ('xinetd.service' in services and services['xinetd.service'].state == 'running') }}
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Install dhcp in pxe server
+  block:
+      - name: Install dhcp in pxe server
+        ansible.builtin.dnf:
+            name:
+                - dhcp-server
+            state: present
+        delegate_to: "{{ groups['pxe'][0] }}"
+
+      - name: Calculate DHCP range from IP (assuming /24 subnet) using bash only
+        ansible.builtin.shell: |
+            ip="{{ host_subnet }}"
+            # Assume /24 subnet
+            cidr=24
+            netmask="255.255.255.0"
+
+            # Extract network base IP
+            IFS=. read -r o1 o2 o3 o4 <<< "$ip"
+            network="${o1}.${o2}.${o3}.0"
+
+            ip_to_dec() {
+            IFS=. read -r a b c d <<< "$1"
+            echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
+            }
+
+            dec_to_ip() {
+            a=$(( ($1 >> 24) & 255 ))
+            b=$(( ($1 >> 16) & 255 ))
+            c=$(( ($1 >> 8) & 255 ))
+            d=$(( $1 & 255 ))
+            echo "$a.$b.$c.$d"
+            }
+
+            net_dec=$(ip_to_dec "$network")
+            mask_dec=$(ip_to_dec "$netmask")
+            broadcast_dec=$(( net_dec | (~mask_dec & 0xFFFFFFFF) ))
+
+            start_dec=$(( net_dec + 10 ))
+            end_dec=$(( broadcast_dec - 1 - 1 ))  # second-to-last usable
+
+            start_ip=$(dec_to_ip "$start_dec")
+            end_ip=$(dec_to_ip "$end_dec")
+
+            echo "dhcp_range_start=$start_ip"
+            echo "dhcp_range_end=$end_ip"
+        register: dhcp_range_output
+
+      - name: Set DHCP range facts
+        ansible.builtin.set_fact:
+            dhcp_range_start: "{{ dhcp_range_output.stdout_lines | select('search', '^dhcp_range_start=') | first | regex_replace('^dhcp_range_start=', '') }}"
+            dhcp_range_end: "{{ dhcp_range_output.stdout_lines | select('search', '^dhcp_range_end=') | first | regex_replace('^dhcp_range_end=', '') }}"
+
+      - name: Add block for dhcp configuration
+        run_once: true
+        ansible.builtin.template:
+            src: templates/dhcp_server_conf.j2
+            dest: "/etc/dhcp/dhcpd.conf"
+            owner: root
+            group: root
+            mode: '0644'
+        delegate_to: "{{ groups['pxe'][0] }}"
+
+      - name: Enable and start dhcp-server
+        ansible.builtin.systemd:
+            name: dhcpd
+            state: started
+            enabled: true
+        delegate_to: "{{ groups['pxe'][0] }}"
+
+      - name: Open DHCP ports in firewall
+        firewalld:
+            service: dhcp
+            permanent: true
+            state: enabled
+            immediate: true
+        delegate_to: "{{ groups['pxe'][0] }}"
+  when: not dhcpd_running
+
+- name: Install tftp in pxe server
+  block:
+      - name: Install tftp in pxe server
+        ansible.builtin.dnf:
+            name: tftp-server
+            state: present
+            use_backend: dnf4
+        delegate_to: "{{ groups['pxe'][0] }}"
+
+      - name: Ensure TFTP root directory exists
+        ansible.builtin.file:
+            path: /var/lib/tftpboot
+            state: directory
+            owner: root
+            group: root
+            mode: '0755'
+        delegate_to: "{{ groups['pxe'][0] }}"
+
+      - name: Enable and start tftp-socket
+        ansible.builtin.systemd:
+            name: tftp.socket
+            state: started
+            enabled: true
+        delegate_to: "{{ groups['pxe'][0] }}"
+
+      - name: Enable and start tftp-server
+        ansible.builtin.systemd:
+            name: tftp.service
+            state: started
+            enabled: true
+        delegate_to: "{{ groups['pxe'][0] }}"
+
+      - name: Install grub2-tools-extra and wget package in pxe server
+        ansible.builtin.dnf:
+            name: grub2-tools-extra
+            state: present
+            use_backend: dnf4
+        delegate_to: "{{ groups['pxe'][0] }}"
+
+      - name: Install wget package in pxe server
+        ansible.builtin.dnf:
+            name: wget
+            state: present
+            use_backend: dnf4
+        delegate_to: "{{ groups['pxe'][0] }}"
+
+      - name: Open TFTP ports in firewall
+        firewalld:
+            service: tftp
+            permanent: true
+            state: enabled
+            immediate: true
+        delegate_to: "{{ groups['pxe'][0] }}"
+  when: not tftp_running
+
+- name: Create Kickstart file name
+  ansible.builtin.set_fact:
+      ks_file: "{{ distro | regex_replace('\\.', '') }}_{{ hardware_ethernet }}.ks"
+
+- name: Create a kickstart file in Repository server
+  run_once: true
+  ansible.builtin.template:
+      src: templates/ks.j2
+      dest: "/var/www/html/{{ ks_file }}"
+  delegate_to: "{{ groups['repo'][0] }}"
+
+- name: Remove any existing tftp boot folder in PXE server for this VM
+  run_once: true
+  ansible.builtin.file:
+      path: "{{ dest_dir }}"
+      state: absent
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Calculate cutdir value
+  ansible.builtin.shell: echo "{{ repo_dir }}" | tr '/' '\n' | grep -v "^$" | wc -l
+  register: cut_dir
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Print the value of dest_dir
+  run_once: true
+  ansible.builtin.debug:
+      msg: "Destination directory is: {{ dest_dir }}"
+
+- name: Download files from /boot and /ppc directory in Repository Server to the PXE server tftp path(hardware address)
+  run_once: true
+  ansible.builtin.shell: wget -r --reject="index.html*" --no-parent -nH --cut-dir={{ cut_dir.stdout | int + 1 }} http://{{ hostvars[groups['repo'][0]].ansible_host }}/{{ repo_dir }}/boot/ -P {{ dest_dir }}
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Download files from /boot and /ppc directory in Repository Server to the PXE server tftp path(hardware address)
+  run_once: true
+  shell: wget -r --reject="index.html*" --no-parent -nH --cut-dir={{ cut_dir.stdout | int + 1 }}   http://{{ hostvars[groups['repo'][0]].ansible_host }}/{{ repo_dir }}/ppc/ -P {{ dest_dir }}
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Create netboot directory in PXE server under tftp path
+  run_once: true
+  shell: grub2-mknetdir --net-directory={{ base_dir }} --subdir={{ mac_address }}/boot/grub/
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Create grub.cfg and copy to boot directory in PXE server
+  run_once: true 
+  template:
+      src: templates/grub_conf.j2
+      dest: "{{ dest_dir }}/boot/grub/grub.cfg"
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: copy to grub.cfg to boot directory in PXE server
+  run_once: true
+  shell: cp "{{ dest_dir }}/boot/grub/grub.cfg" "{{ dest_dir }}/boot/grub/powerpc-ieee1275/grub.cfg-01-{{ address }}"
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Backup the dhcp file , if in case this blocks add any errors
+  run_once: true
+  shell: cp /etc/dhcp/dhcpd.conf /tmp/dhcpd.conf
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: DHCP block file to add lpar entry into dhcpd.conf
+  run_once: true
+  blockinfile:
+    dest: /etc/dhcp/dhcpd.conf
+    marker: "#{mark} Ansible module dhcp entry"
+    block: "{{ lookup('template', 'dhcpd_conf.j2') }}"
+    state: present
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Restart dhcp-server
+  run_once: true
+  ansible.builtin.systemd:
+    name: dhcpd
+    state: restarted
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Lparnetboot operation on target lpar
+  run_once: true
+  connection: local
+  collections:
+      - ibm.power_hmc
+  powervm_lpar_instance:
+      hmc_host: "{{ hostvars['hmc_server'].ansible_host }}"
+      hmc_auth: "{{ curr_hmc_auth }}"
+      system_name: "{{ managed_system }}"
+      vm_name: "{{ lpar_name }}"
+      install_settings:
+          vm_ip: "{{ host_ip }}"
+          nim_ip: "{{ hostvars['pxe_server'].ansible_host }}"
+          nim_gateway: "{{ host_gw }}"
+          nim_subnetmask: "{{ host_netmask }}"
+          vm_mac: "{{ mac_address }}"
+          timeout: 11
+      action: install_os
+  ignore_errors: yes
+  delegate_to: "{{ groups['hmcs'][0] }}"
+
+- name: Revert the DHCP configuration changes in PXE server, take a backup of configuration file
+  run_once: true
+  shell: cp /etc/dhcp/dhcpd.conf /tmp/dhcpd.conf
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: block file
+  run_once: true
+  blockinfile:
+    dest: /etc/dhcp/dhcpd.conf
+    marker: "#{mark} Ansible module dhcp entry"
+    block: "{{ lookup('template', 'dhcpd_conf.j2') }}"
+    state: absent
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Restart dhcp-server
+  run_once: true
+  ansible.builtin.systemd:
+    name: dhcpd
+    state: restarted
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Wait for host SSH to become available after install
+  run_once: true
+  wait_for_connection:
+    timeout: 10
+    sleep: 5
+  vars:
+      ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+      ansible_host: "{{ host_ip }}"
+
+- name: Ensure system facts are gathered from the VM
+  run_once: true
+  setup:
+  vars:
+      ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  delegate_to: "{{ groups['vm'][0] }}"
+
+- name: Print OS info from the VM
+  run_once: true
+  debug:
+    msg: "Distribution: {{ ansible_facts['distribution'] }}, Version: {{ ansible_facts['distribution_version'] }}"
+  delegate_to: "{{ groups['vm'][0] }}"

--- a/roles/redhat_linux_install/templates/dhcp_server_conf.j2
+++ b/roles/redhat_linux_install/templates/dhcp_server_conf.j2
@@ -1,0 +1,8 @@
+default-lease-time 600;
+max-lease-time 7200;
+authoritative;
+subnet {{ host_subnet }} netmask {{ host_netmask }} {
+  range {{dhcp_range_start}} {{ dhcp_range_end }};
+  option routers {{ host_gw }};
+  option domain-name-servers {{ dns_ip }};
+}

--- a/roles/redhat_linux_install/templates/dhcpd_conf.j2
+++ b/roles/redhat_linux_install/templates/dhcpd_conf.j2
@@ -1,0 +1,15 @@
+subnet {{ host_subnet }} netmask {{ host_netmask }} {
+    allow bootp;
+    option routers {{ host_gw }};
+    option domain-name-servers {{ dns_ip }};
+    group {
+        next-server {{ hostvars[groups['pxe'][0]].ansible_host }};
+        filename "{{ core_file_path }}";
+        host {{ hostname }} {
+            hardware ethernet {{ hardware_ethernet }};
+            fixed-address {{ host_ip }};
+            option host-name {{ lpar_name }};
+            option tftp-server-name "{{ hostvars[groups['pxe'][0]].ansible_host }}";
+        }
+    }
+}

--- a/roles/redhat_linux_install/templates/grub_conf.j2
+++ b/roles/redhat_linux_install/templates/grub_conf.j2
@@ -1,0 +1,9 @@
+set timeout=1
+menuentry 'Install OS' {
+    insmod http
+    insmod tftp
+    set root=tftp,{{ hostvars[groups['pxe'][0]].ansible_host }}
+    echo 'Loading OS Install kernel ...'
+    linux {{ mac_address }}/ppc/ppc64/vmlinuz ifname=net0:{{ hardware_ethernet }} ip={{ host_ip }}::{{ host_gw }}:{{ host_netmask }}:{{ hostname }}:net0:none nameserver={{ dns_ip }} inst.repo=http://{{ hostvars[groups['repo'][0]].ansible_host }}/{{ repo_dir }}/ inst.ks=http://{{ hostvars[groups['repo'][0]].ansible_host }}/{{ ks_file }}
+    initrd {{ mac_address }}/ppc/ppc64/initrd.img
+}

--- a/roles/redhat_linux_install/templates/ks.j2
+++ b/roles/redhat_linux_install/templates/ks.j2
@@ -1,0 +1,56 @@
+%pre
+%end
+# Use network installation
+url --url="http://{{ hostvars[groups['repo'][0]].ansible_host }}:{{ repo_port }}/{{ repo_dir }}/BaseOS"
+
+# Use text mode install
+text
+
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+
+# System language
+lang en_US.UTF-8
+
+# Root password
+rootpw --plaintext {{ host_password }}
+
+# Do not configure the X Window System
+skipx
+
+# System timezone
+timezone Asia/Kolkata --utc
+
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel --drives=sda
+
+# System bootloader configuration
+bootloader --append="crashkernel=2G-4G:384M,4G-16G:512M,16G-64G:1G,64G-128G:2G,128G-:4G" --location=mbr --boot-drive=sda
+
+
+# Generated using Blivet version 3.6.0
+ignoredisk --only-use=sda
+
+autopart --fstype=ext4
+
+# System services
+services --enabled="NetworkManager,sshd"
+
+# Reboot after installation
+reboot
+
+%packages
+@core
+device-mapper-multipath
+kexec-tools
+%end
+
+%post
+sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config;service sshd restart;multipath -t >/etc/multipath.conf;service multipathd start
+%end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+
+%end

--- a/roles/redhat_linux_install/vars/main.yml
+++ b/roles/redhat_linux_install/vars/main.yml
@@ -1,0 +1,34 @@
+---
+# Redhat Release Name
+distro: 
+
+# Path to the build files in Repository server
+repo_dir: 
+
+# Tftp boot directory path in PXE server
+base_dir: /var/lib/tftpboot/
+
+# Append base directory path with a new directory named by mac address
+dest_dir: "{{ base_dir }}{{ mac_address }}"
+
+# Set core elf file path in PXE server
+core_file_path: "{{ mac_address }}/boot/grub/powerpc-ieee1275/core.elf"
+
+# HMC credentials
+curr_hmc_auth:
+        username: "{{ hostvars[groups['hmcs'][0]].ansible_user }}"
+        password: "{{ hostvars[groups['hmcs'][0]].ansible_password }}"
+
+# Host Details
+host_ip: 9.1.1.10
+host_gw: 9.1.1.1
+host_subnet: 9.1.1.0
+host_netmask: 255.255.255.0
+dns_ip: 9.0.0.0
+hostname: vm.abc.com
+lpar_name: vm-hmc
+managed_system: vm-abc
+host_password: abc123
+proc: 2
+disk_size: 28590
+mem: 2048


### PR DESCRIPTION
Role have been added to automate linux installation and roles has below steps to achieve it ,
1. Kickstart file creation - Drive the automated OS installation
2. DHCP  in pxe server- Add the lpar entry in DHCP config file inside DHCP server
3. TFTP in pxe server - Add the tftp/grub related files for OS to be installed in accordance with lpar mac address
4. DHCP cleanup in pxe server - cleanup the DHCP config for the lpar created

This role will take care to start and enable the dhcp and tftp server on PXE server, if its unavailable 