### PR TITLE
Adding roles and playbook for SUSE LINUX Installation

### DIFF
--- a/playbooks/suse-install.yaml
+++ b/playbooks/suse-install.yaml
@@ -1,0 +1,26 @@
+---
+- name: Install linux
+  hosts: localhost
+  collections:
+    - ibm.power_hmc
+    - ansible.netcommon
+  gather_facts: False
+  roles:
+    - role: sles_linux_install
+      vars:
+
+        distro: sles16
+        install_protocol: http
+        repo_port: 81
+        repo_dir: /sles/
+        host_ip: 9.xx.xx.xx
+        host_gw: 9.xx.xx.xx
+        host_subnet: 9.xx.xx.xx
+        host_netmask: 255.xxx.xxx.xx
+        dns_ip: 9.x.x.x
+        hostname: ltcvm-lp3.xxx.xxxxxxx.ibm.com
+        lpar_name: ltcvm-lp3
+        hardware_ethernet: xx:xx:xx:xx:xx:xx
+        managed_system: ltcvm
+        host_password: "{{ hostvars[groups['vm'][0]].ansible_password }}"
+        disk_id: scsi-SAIX_VDASD_xxxxxxxxxxxc0000000xxxxxxxxxxx.x

--- a/roles/sles_linux_install/README.md
+++ b/roles/sles_linux_install/README.md
@@ -1,0 +1,44 @@
+
+# SUSE Linux Installation Role for IBM PowerVM
+
+This Ansible role automates the process of installing SUSE LINUX on IBM PowerVM logical partitions (LPARs) using a **network-based installation via TFTP boot**.
+
+## Overview
+
+There are multiple ways to install SUSE on IBM Power servers. This role focuses on automating the **TFTP-based network installation** method using Ansible. It sets up the necessary infrastructure and orchestrates the installation process end-to-end.
+
+## Required Infrastructure
+
+To perform the installation, the following components must be configured:
+
+1. **HTTP (Repo) Server**  
+   Hosts the SUSE distribution files and serves them via HTTP. This can be a dedicated server with multiple distro builds or a simple HTTP server with the required build.
+
+2. **PXE Server**  
+   Runs both `tftpd` and `dhcpd` services. This role will configure these services if they are not already running.
+
+3. **LPAR (Logical Partition)**  
+   The target system where SUSE will be installed.
+
+## Role Workflow
+
+1. **PXE Server Setup**  
+   - Checks for running DHCP and TFTP services.
+   - If not found, configures and enables them.
+   - DHCP configuration is dynamically generated based on the subnet of the target LPAR using the `dhcp_server_conf.j2` template.
+   - TFTP is configured to serve files from `/var/lib/tftpboot`.
+
+2. **Kickstart File Generation**  
+   - A kickstart file is created on the HTTP server containing the installation configuration.
+
+3. **Boot File Preparation**  
+   - Required boot files are downloaded to the PXE server.
+   - A GRUB configuration file is generated using the kickstart file.
+
+4. **Network Boot Trigger**  
+   - The `lpar_netboot` command is executed from the HMC to initiate a network boot on the LPAR.
+   - The LPAR sends a BOOTP request to the PXE server and begins the OS installation.
+
+## Post-Installation Validation
+
+After installation, the role prints the OS distribution name and version installed on the LPAR to verify success.

--- a/roles/sles_linux_install/meta/main.yml
+++ b/roles/sles_linux_install/meta/main.yml
@@ -1,0 +1,12 @@
+galaxy_info:
+  author: Naveen Kumar T
+  description: SUSE Linux installation using pxe server
+  license: GPL-3.0-only
+  min_ansible_version: '>=2.14.0'
+  galaxy_tags:
+    - infrastructure
+    - ibm
+    - power
+    - hmc
+    - linux
+    - pxe

--- a/roles/sles_linux_install/tasks/main.yml
+++ b/roles/sles_linux_install/tasks/main.yml
@@ -1,0 +1,278 @@
+---
+- name: Gather service facts
+  run_once: true
+  service_facts:
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Check if the pxe server has dhcp and tftp services running
+  run_once: true
+  set_fact:
+    dhcpd_running: "{{ 'dhcpd.service' in services and services['dhcpd.service'].state == 'running' }}"
+    tftp_running: >-
+      {{ ('tftp.service' in services and services['tftp.service'].state == 'running') or
+         ('xinetd.service' in services and services['xinetd.service'].state == 'running') }}
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Install dhcp in pxe server
+  block:
+    - name: Install dhcp in pxe server
+      dnf:
+        name:
+          - dhcp-server
+        state: present
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Calculate DHCP range from IP (assuming /24 subnet) using bash only
+      shell: |
+          ip="{{ host_subnet }}"
+          # Assume /24 subnet
+          cidr=24
+          netmask="255.255.255.0"
+
+          # Extract network base IP
+          IFS=. read -r o1 o2 o3 o4 <<< "$ip"
+          network="${o1}.${o2}.${o3}.0"
+
+          ip_to_dec() {
+          IFS=. read -r a b c d <<< "$1"
+          echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
+          }
+
+          dec_to_ip() {
+          a=$(( ($1 >> 24) & 255 ))
+          b=$(( ($1 >> 16) & 255 ))
+          c=$(( ($1 >> 8) & 255 ))
+          d=$(( $1 & 255 ))
+          echo "$a.$b.$c.$d"
+          }
+
+          net_dec=$(ip_to_dec "$network")
+          mask_dec=$(ip_to_dec "$netmask")
+          broadcast_dec=$(( net_dec | (~mask_dec & 0xFFFFFFFF) ))
+
+          start_dec=$(( net_dec + 10 ))
+          end_dec=$(( broadcast_dec - 1 - 1 ))  # second-to-last usable
+
+          start_ip=$(dec_to_ip "$start_dec")
+          end_ip=$(dec_to_ip "$end_dec")
+
+          echo "dhcp_range_start=$start_ip"
+          echo "dhcp_range_end=$end_ip"
+      register: dhcp_range_output
+
+    - name: Set DHCP range facts
+      set_fact:
+        dhcp_range_start: "{{ dhcp_range_output.stdout_lines | select('search', '^dhcp_range_start=') | first | regex_replace('^dhcp_range_start=', '') }}"
+        dhcp_range_end: "{{ dhcp_range_output.stdout_lines | select('search', '^dhcp_range_end=') | first | regex_replace('^dhcp_range_end=', '') }}"
+
+    - name: Debug
+      debug:
+        msg: "{{ dhcp_range_start }} {{ dhcp_range_end }}"
+
+    - name: Add block for dhcp configuration
+      run_once: true
+      template:
+        src: templates/dhcp_server_conf.j2
+        dest: "/etc/dhcp/dhcpd.conf"
+        owner: root
+        group: root
+        mode: '0644'
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Enable and start dhcp-server
+      systemd:
+        name: dhcpd
+        state: started
+        enabled: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Open DHCP ports in firewall
+      firewalld:
+        service: dhcp
+        permanent: true
+        state: enabled
+        immediate: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+  when: not dhcpd_running
+
+- name: Install tftp in pxe server
+  block:
+    - name: Install tftp in pxe server
+      dnf:
+        name: tftp-server
+        state: present
+        use_backend: dnf4
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Ensure TFTP root directory exists
+      file:
+        path: /var/lib/tftpboot
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+      delegate_to: "{{ groups['pxe'][0] }}"
+    
+    - name: Enable and start tftp-socket
+      systemd:
+        name: tftp.socket
+        state: started
+        enabled: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Enable and start tftp-server
+      systemd:
+        name: tftp.service
+        state: started
+        enabled: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Install grub2-tools-extra and wget package in pxe server
+      dnf:
+        name: grub2-tools-extra
+        state: present
+        use_backend: dnf4
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Install wget package in pxe server
+      dnf:
+        name: wget
+        state: present
+        use_backend: dnf4
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Open TFTP ports in firewall
+      firewalld:
+        service: tftp
+        permanent: true
+        state: enabled
+        immediate: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+  when: not tftp_running
+
+- name: Create Kickstart file name
+  set_fact:
+    ks_file: "{{ distro | regex_replace('\\.', '') }}_{{ hardware_ethernet }}.jsonnet"
+
+- name: Create a kickstart file in Repository server
+  run_once: true
+  template:
+    src: templates/jsonnet.j2
+    dest: "/var/www/html/{{ ks_file }}"
+  delegate_to: "{{ groups['repo'][0] }}"
+
+- name: Remove any existing tftp boot folder in PXE server for this VM
+  run_once: true
+  shell: rm -rf "{{ dest_dir }}"
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Calculate cutdir value
+  shell: echo "{{ repo_dir }}" | tr '/' '\n' | grep -v "^$" | wc -l
+  register: cut_dir
+
+- name: Download files from /LiveOS/Squashfs  in Repository Server to the PXE server tftp path(hardware address)
+  run_once: true
+  shell: wget -r --reject="index.html*" --no-parent -nH --cut-dir={{ cut_dir.stdout | int + 1 }}   http://{{ hostvars[groups['repo'][0]].ansible_host }}:{{ repo_port }}/{{ repo_dir }}/LiveOS/squashfs.img  -P {{ dest_dir }}/  
+  delegate_to: "{{ groups['pxe'][0] }}" 
+
+- name: Download files from /boot and /ppc directory in Repository Server to the PXE server tftp path(hardware address)
+  run_once: true
+  shell: wget -r --reject="index.html*" --no-parent -nH --cut-dir={{ cut_dir.stdout | int + 1 }}   http://{{ hostvars[groups['repo'][0]].ansible_host }}:{{ repo_port }}/{{ repo_dir }}/boot/ -P {{ dest_dir }}
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+
+- name: Create netboot directory in PXE server under tftp path
+  run_once: true
+  shell: grub2-mknetdir --net-directory={{ base_dir }} --subdir={{ mac_address }}/boot/ppc64le/grub2-ieee1275/
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Create grub.cfg in  PXE server
+  run_once: true 
+  template:
+    src: templates/grub_conf.j2
+    dest: "{{ dest_dir }}/boot/grub2/grub.cfg"
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: copy to grub.cfg to boot directory in PXE server
+  run_once: true
+  shell: cp "{{ dest_dir }}/boot/grub2/grub.cfg" "{{ dest_dir }}/boot/ppc64le/grub2-ieee1275/grub.cfg"
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Backup the dhcp file , if in case this blocks add any errors
+  run_once: true
+  shell: cp /etc/dhcp/dhcpd.conf /tmp/dhcpd.conf
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: DHCP block file to add lpar entry into dhcpd.conf
+  run_once: true
+  blockinfile:
+    dest: /etc/dhcp/dhcpd.conf
+    marker: "#{mark} Ansible module dhcp entry"
+    block: "{{ lookup('template', 'dhcpd_conf.j2') }}"
+    state: present
+  delegate_to: "{{ groups['pxe'][0] }}"
+   
+- name: restart dhcp service
+  run_once: true
+  shell: systemctl restart  dhcpd.service
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Lparnetboot operation on target lpar
+  run_once: true
+  connection: local
+  collections:
+      - ibm.power_hmc
+  powervm_lpar_instance:
+        hmc_host: "{{ hostvars[groups['hmcs'][0]].ansible_host }}"
+        hmc_auth: "{{ curr_hmc_auth }}"
+        system_name: "{{ managed_system }}"
+        vm_name: "{{ lpar_name }}"
+        install_settings:
+          vm_ip: "{{ host_ip }}"
+          nim_ip: "{{ hostvars[groups['pxe'][0]].ansible_host }}"
+          nim_gateway: "{{ host_gw }}"
+          nim_subnetmask: "{{ host_netmask }}"
+          vm_mac: "{{ mac_address }}"
+          timeout: 13
+        action: install_os
+  ignore_errors: yes
+  delegate_to: "{{ groups['hmcs'][0] }}"
+
+- name: Revert the DHCP configuration changes in PXE server, take a backup of configuration file
+  run_once: true
+  shell: cp /etc/dhcp/dhcpd.conf /tmp/dhcpd.conf
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: block file
+  run_once: true
+  blockinfile:
+    dest: /etc/dhcp/dhcpd.conf
+    marker: "#{mark} Ansible module dhcp entry"
+    block: "{{ lookup('template', 'dhcpd_conf.j2') }}"
+    state: absent
+  delegate_to: "{{ groups['pxe'][0] }}"
+  
+- name: resatart dhcp
+  run_once: true
+  shell: systemctl restart  dhcpd.service
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Wait for host SSH to become available after install
+  run_once: true
+  wait_for_connection:
+    timeout: 10
+    sleep: 5
+  vars:
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  delegate_to: "{{ groups['vm'][0] }}"
+
+- name: Ensure system facts are gathered from the VM
+  run_once: true
+  setup:
+  delegate_to: "{{ groups['vm'][0] }}"
+
+- name: Print OS info from the VM
+  run_once: true
+  debug:
+    msg: "Distribution: {{ ansible_facts['distribution'] }}, Version: {{ ansible_facts['distribution_version'] }}"

--- a/roles/sles_linux_install/templates/dhcp_server_conf.j2
+++ b/roles/sles_linux_install/templates/dhcp_server_conf.j2
@@ -1,0 +1,8 @@
+default-lease-time 600;
+max-lease-time 7200;
+authoritative;
+subnet {{ host_subnet }} netmask {{ host_netmask }} {
+  range {{dhcp_range_start}} {{ dhcp_range_end }};
+  option routers {{ host_gw }};
+  option domain-name-servers {{ dns_ip }};
+}

--- a/roles/sles_linux_install/templates/dhcpd_conf.j2
+++ b/roles/sles_linux_install/templates/dhcpd_conf.j2
@@ -1,0 +1,15 @@
+subnet {{ host_subnet }} netmask {{ host_netmask }} {
+    allow bootp;
+    option routers {{ host_gw }};
+    option domain-name-servers {{ dns_ip }};
+    group {
+        next-server {{ hostvars[groups['pxe'][0]].ansible_host }};
+        filename "{{ core_file_path }}";
+        host {{ hostname }} {
+            hardware ethernet {{ hardware_ethernet }};
+            fixed-address {{ host_ip }};
+            option host-name {{ lpar_name }};
+            option tftp-server-name "{{ hostvars[groups['pxe'][0]].ansible_host }}";
+        }
+    }
+}

--- a/roles/sles_linux_install/templates/grub_conf.j2
+++ b/roles/sles_linux_install/templates/grub_conf.j2
@@ -1,0 +1,17 @@
+set timeout=1
+menuentry 'Install OS' {
+    insmod http
+    insmod tftp
+    set root=tftp,{{ hostvars[groups['pxe'][0]].ansible_host }}
+    echo 'Loading OS Install kernel ...'
+
+    linux {{ mac_address }}/boot/ppc64le/linux \
+    rd.neednet=1 ip={{ host_ip }}::{{ host_gw }}:{{ host_netmask }}:{{ hostname }}::none \
+    nameserver={{ dns_ip }} \
+    agama.install_url={{ install_protocol }}://{{ hostvars[groups['repo'][0]].ansible_host }}{% if install_protocol == 'http' %}:{{ repo_port }}{% endif %}/{{ repo_dir }}/install \
+    root=live:{{ install_protocol }}://{{ hostvars[groups['repo'][0]].ansible_host }}{% if install_protocol == 'http' %}:{{ repo_port }}{% endif %}/{{ repo_dir }}/LiveOS/squashfs.img \
+    live.password=abc123 \
+    inst.auto={{ install_protocol }}://{{ hostvars[groups['repo'][0]].ansible_host }}{% if install_protocol == 'http' %}:{{ repo_port }}{% endif %}/{{ ks_file }}
+
+    initrd {{ mac_address }}/boot/ppc64le/initrd
+}

--- a/roles/sles_linux_install/templates/jsonnet.j2
+++ b/roles/sles_linux_install/templates/jsonnet.j2
@@ -1,0 +1,80 @@
+{
+  "bootloader": {
+    "stopOnBootMenu": false
+  },
+  "user": {
+    "fullName": "abc",
+    "userName": "abc",
+    "password": "abc123",
+    "hashedPassword": false,
+    "autologin": false
+  },
+  "root": { "hashedPassword": false, "password": "{{ host_password }}" },
+  "software": {
+    "patterns": []
+  },
+  "product": {
+    "id": "SLES"
+  },
+  "storage": {
+"drives": [
+{
+"search": "/dev/disk/by-id/{{ disk_id }}",
+"partitions": [
+{ "search": "*", "delete": true },
+{
+"filesystem": { "path": "/" },
+"size": { "min": "10 GiB" }
+},
+{
+"filesystem": { "path": "swap" },
+"size": { "min": "1 GiB", "max": "4 GiB" }
+}
+]
+}
+]
+},
+  "network": {
+    "connections": [
+      {
+        "id": "Wired Connection",
+        "method4": "manual",
+        "gateway4": "{{ host_gw }}",
+        "method6": "disabled",
+        "addresses": [
+          "{{ host_ip }}/ {{ host_netmask | ansible.utils.ipaddr('prefix') }}"
+        ],
+        "nameservers": [
+          "{{ dns_ip }}"
+        ],
+        "ignoreAutoDns": false,
+        "status": "up",
+        "autoconnect": true
+      }
+    ]
+  },
+  "localization": {
+    "language": "en_US.UTF-8",
+    "keyboard": "us",
+    "timezone": "Europe/Berlin"
+  },
+scripts: {
+                post: [
+                    {
+            name: "permit-root-login",
+            content: |||
+                #!/bin/bash
+                ssh_file="/usr/etc/ssh/sshd_config"
+                backup_file="/usr/etc/ssh/sshd_config.bak.$(date +%F_%T)"
+                cp "$ssh_file" "$backup_file"
+                if grep -q "^PermitRootLogin" "$ssh_file"; then
+                    sed -i "s/^PermitRootLogin.*/PermitRootLogin yes/" "$ssh_file"
+                else
+                    echo "PermitRootLogin yes" >> "$ssh_file"
+                fi
+                systemctl enable sshd.service
+            |||
+        }
+                ]
+            }
+}

--- a/roles/sles_linux_install/vars/main.yml
+++ b/roles/sles_linux_install/vars/main.yml
@@ -1,0 +1,49 @@
+---
+
+# Redhat Release Name
+distro: 
+
+# Repository Port Number 
+repo_port: 
+
+# Path to the build files in Repository server
+repo_dir: 
+
+# Tftp boot directory path in PXE server
+base_dir: /var/lib/tftpboot/
+
+# Remove ':' in hardware ethernet address
+mac_address: "{{ hardware_ethernet | regex_replace(':', '') }}"
+
+# Append base directory path with a new directory named by mac address
+dest_dir: "{{ base_dir }}{{ mac_address }}"
+
+# Set core elf file path in PXE server
+core_file_path: "{{ mac_address }}/boot/ppc64le/grub2-ieee1275/powerpc-ieee1275/core.elf"
+
+# Replace ':' in hardware ethernet address wit '-'
+address: "{{ hardware_ethernet | regex_replace(':', '-') }}"
+
+# Install params
+install_protocol: ftp
+
+# HMC credentials
+curr_hmc_auth:
+        username: "{{ hostvars[groups['hmcs'][0]].ansible_user }}"
+        password: "{{ hostvars[groups['hmcs'][0]].ansible_password }}"
+
+# Host Details
+host_ip: 9.1.1.10
+host_gw: 9.1.1.1
+host_subnet: 9.1.1.0
+host_netmask: 255.255.255.0
+dns_ip: 9.0.0.0
+hostname: vm.abc.com
+lpar_name: vm-hmc
+hardware_ethernet: aa:aa:aa:aa:aa:aa 
+managed_system: vm-abc
+host_password: password
+
+
+
+


### PR DESCRIPTION
Role and Playbook have been added to Automate Linux Installation.

**Playbook:**
- Built to support SUSE Linux installations with customizable input variables
- Handles end-to-end orchestration from PXE boot to post-install validation

**Templetes:**
- jsonnet.j2.   Dynamically generates Kickstart files for SUSE OS configuration
- grub_conf.j2.   Constructs GRUB bootloader config for PXE-based installation
- dhcpd_conf.j2	Adds VM-specific static DHCP entry to DHCP server config
- dhcp_server_conf.j2	Creates or updates the main DHCP configuration file

**vars/main.yml:** Defines SUSE-specific installation variables, including boot parameters, network details, and build paths.
**tasks/main.yml:** Contains the main task sequence for automating Linux OS installation using Ansible—covers PXE boot setup, GRUB configuration, kickstart generation, and post-install validation.